### PR TITLE
Integrate Suno API song generation flow

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,8 +1,42 @@
 const express = require('express');
+const fs = require('fs');
 const path = require('path');
 const { fetchTopNews } = require('./newsService');
 
+function loadEnv() {
+  const envFile = path.join(__dirname, '..', '.env');
+
+  if (process.env.suno_api || !fs.existsSync(envFile)) {
+    return;
+  }
+
+  try {
+    const contents = fs.readFileSync(envFile, 'utf8');
+    contents
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith('#'))
+      .forEach((line) => {
+        const [key, ...rest] = line.split('=');
+        if (!key || rest.length === 0) {
+          return;
+        }
+
+        const value = rest.join('=').trim().replace(/^['"]|['"]$/g, '');
+
+        if (!Object.prototype.hasOwnProperty.call(process.env, key)) {
+          process.env[key] = value;
+        }
+      });
+  } catch (error) {
+    console.warn('Unable to read .env file:', error.message);
+  }
+}
+
+loadEnv();
+
 const app = express();
+app.use(express.json());
 
 const songs = [
   {
@@ -51,6 +85,72 @@ app.get('/', (_req, res) => {
 
 app.get('/api/songs', (_req, res) => {
   res.json(songs);
+});
+
+function buildSongPrompt(stories) {
+  const intro = "Write imaginative lyrics for a short song summarizing today's top news headlines. Keep the tone thoughtful but hopeful.";
+
+  const formattedHeadlines = stories
+    .map((story, index) => {
+      const summaryPart = story.summary ? ` — ${story.summary}` : '';
+      return `${index + 1}. ${story.headline}${summaryPart}`;
+    })
+    .join('\n');
+
+  return `${intro}\n\nHeadlines:\n${formattedHeadlines}`;
+}
+
+app.post('/api/generate-song', async (_req, res) => {
+  try {
+    const apiKey = process.env.suno_api;
+
+    if (!apiKey) {
+      res.status(500).json({ error: 'Suno API key is not configured.' });
+      return;
+    }
+
+    const stories = await fetchTopNews(5);
+
+    if (!stories.length) {
+      res.status(503).json({ error: 'No news headlines are available right now.' });
+      return;
+    }
+
+    const prompt = buildSongPrompt(stories);
+
+    const response = await fetch('https://api.sunoapi.com/api/v1/suno/create', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        custom_mode: false,
+        gpt_description_prompt: prompt,
+        make_instrumental: false,
+        mv: 'chirp-v5',
+      }),
+    });
+
+    const rawBody = await response.text();
+
+    if (!response.ok) {
+      res.status(response.status).json({ error: 'Suno API request failed.', details: rawBody });
+      return;
+    }
+
+    let parsed;
+    try {
+      parsed = JSON.parse(rawBody);
+    } catch (error) {
+      parsed = rawBody;
+    }
+
+    res.json({ success: true, prompt, suno: parsed });
+  } catch (error) {
+    console.error('Unable to generate song with Suno API:', error);
+    res.status(500).json({ error: 'Unable to generate song at this time.' });
+  }
 });
 
 const port = process.env.PORT || 3000;

--- a/components/index.html
+++ b/components/index.html
@@ -196,6 +196,47 @@
       text-align: center;
       padding: 2rem;
     }
+
+    .generate-song {
+      margin-top: auto;
+      padding-top: 1.25rem;
+      border-top: 1px solid rgba(148, 163, 184, 0.15);
+      display: flex;
+      flex-direction: column;
+      gap: 0.6rem;
+    }
+
+    .generate-song button {
+      appearance: none;
+      border: none;
+      border-radius: 14px;
+      padding: 0.85rem 1.2rem;
+      background: linear-gradient(135deg, rgba(245, 158, 11, 0.92), rgba(234, 179, 8, 0.85));
+      color: #0f172a;
+      font-weight: 600;
+      font-size: 1rem;
+      cursor: pointer;
+      transition: transform 0.15s ease, box-shadow 0.2s ease;
+      box-shadow: 0 12px 32px rgba(245, 158, 11, 0.28);
+    }
+
+    .generate-song button:hover:not(:disabled) {
+      transform: translateY(-2px);
+      box-shadow: 0 16px 36px rgba(245, 158, 11, 0.34);
+    }
+
+    .generate-song button:disabled {
+      cursor: not-allowed;
+      opacity: 0.7;
+      transform: none;
+      box-shadow: none;
+    }
+
+    .generate-song-status {
+      font-size: 0.9rem;
+      color: var(--muted);
+      min-height: 1.4em;
+    }
   </style>
 </head>
 <body>
@@ -222,6 +263,11 @@
 
       <section class="lyrics" id="songDescription">
         Choose a song to read a short story about why it made the Daily Spin playlist.
+      </section>
+
+      <section class="generate-song">
+        <button type="button" id="generateSongButton">Generate Suno Song</button>
+        <p class="generate-song-status" id="generateSongStatus" aria-live="polite"></p>
       </section>
     </main>
   </div>
@@ -319,7 +365,70 @@
       });
     }
 
-    document.addEventListener('DOMContentLoaded', loadSongs);
+    function describeSunoResult(result) {
+      if (!result || typeof result !== 'object') {
+        return '';
+      }
+
+      if (Array.isArray(result.data) && result.data.length > 0) {
+        const first = result.data[0];
+        const identifier = first.id || first.song_id || first.audio_id || first.task_id;
+        if (identifier) {
+          return `Suno request queued (ID: ${identifier}).`;
+        }
+      }
+
+      if (result.id || result.song_id || result.audio_id) {
+        const identifier = result.id || result.song_id || result.audio_id;
+        return `Suno request queued (ID: ${identifier}).`;
+      }
+
+      if (result.status) {
+        return `Suno responded with status: ${result.status}.`;
+      }
+
+      return '';
+    }
+
+    async function generateSongFromNews() {
+      const button = document.getElementById('generateSongButton');
+      const status = document.getElementById('generateSongStatus');
+
+      if (!button || !status) {
+        return;
+      }
+
+      button.disabled = true;
+      status.textContent = 'Crafting a Suno prompt from today\'s headlines...';
+
+      try {
+        const response = await fetch('/api/generate-song', { method: 'POST' });
+        if (!response.ok) {
+          const error = await response.json().catch(() => ({}));
+          const message = error.error || 'Unable to reach the Suno API.';
+          throw new Error(message);
+        }
+
+        const payload = await response.json();
+        console.log('Suno API response', payload);
+
+        const summary = describeSunoResult(payload.suno);
+        status.textContent = summary || 'Your Suno song request was created! Check the console for full details.';
+      } catch (error) {
+        console.error('Failed to generate Suno song:', error);
+        status.textContent = error.message || 'Something went wrong while generating the song.';
+      } finally {
+        button.disabled = false;
+      }
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      loadSongs();
+      const button = document.getElementById('generateSongButton');
+      if (button) {
+        button.addEventListener('click', generateSongFromNews);
+      }
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load Suno API credentials from the environment and expose a /api/generate-song endpoint that composes prompts from the latest headlines
- add a “Generate Suno Song” control with styling and status messaging that requests new tracks from the backend

## Testing
- npm start *(fails to reach external news feed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e57d77a0e8832586a088cef82bdccf