### PR TITLE
Add Firebase-backed recent spins

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -38,53 +38,28 @@ loadEnv();
 const app = express();
 app.use(express.json());
 
-const songs = [
-  {
-    title: 'Neon Skyline',
-    artist: 'Aurora Lane',
-    date: '2024-04-22',
-    isToday: true,
-    streamUrl: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3',
-    description:
-      'A shimmering synth-pop ode to city lights and long walks after midnight. Layered pads pulse beneath Aurora\'s hushed vocal, making this an easy repeat listen for winding down the day.',
-  },
-  {
-    title: 'Golden Hour Coffee',
-    artist: 'Sam Torres',
-    date: '2024-04-21',
-    isToday: false,
-    streamUrl: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-2.mp3',
-    description:
-      'Acoustic guitar, brushed drums, and the gentle swirl of Sam\'s falsetto conjure the very best lazy Sunday morning vibes. Brew a cup and let this one warm the room.',
-  },
-  {
-    title: 'Bloom Sequence',
-    artist: 'Circuit Garden',
-    date: '2024-04-20',
-    isToday: false,
-    streamUrl: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-3.mp3',
-    description:
-      'Modular pulses gradually unfold into a lush, cinematic crescendo. Circuit Garden blends organic field recordings with analog drift for a track that feels alive.',
-  },
-  {
-    title: 'Skylark Avenue',
-    artist: 'Indigo Knots',
-    date: '2024-04-19',
-    isToday: false,
-    streamUrl: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-4.mp3',
-    description:
-      'A breezy slice of indie pop packed with chiming guitars and a chorus that sticks. Indigo Knots channel the excitement of the first warm day after a long winter.',
-  },
-];
-
 app.use(express.static(path.join(__dirname, '..', 'public')));
 
 app.get('/', (_req, res) => {
   res.sendFile(path.join(__dirname, '..', 'components', 'index.html'));
 });
 
-app.get('/api/songs', (_req, res) => {
-  res.json(songs);
+app.get('/api/firebase-config', (_req, res) => {
+  const config = {
+    apiKey: process.env.FIREBASE_API_KEY,
+    authDomain: process.env.FIREBASE_AUTH_DOMAIN,
+    databaseURL: process.env.FIREBASE_DATABASE_URL,
+    projectId: process.env.FIREBASE_PROJECT_ID,
+    storageBucket: process.env.FIREBASE_STORAGE_BUCKET,
+    messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID,
+    appId: process.env.FIREBASE_APP_ID,
+  };
+
+  if (!config.apiKey || !config.projectId) {
+    return res.status(500).json({ error: 'Firebase configuration is missing.' });
+  }
+
+  res.json(config);
 });
 
 function buildSongPrompt(stories) {

--- a/components/index.html
+++ b/components/index.html
@@ -186,6 +186,7 @@
       font-size: 0.95rem;
       line-height: 1.7;
       color: rgba(226, 232, 240, 0.9);
+      white-space: pre-wrap;
       max-height: 200px;
       overflow-y: auto;
       padding-right: 0.75rem;
@@ -281,56 +282,44 @@
     </li>
   </template>
 
-  <script>
-    async function loadSongs() {
-      try {
-        const response = await fetch('/api/songs');
-        if (!response.ok) throw new Error('Unable to load songs');
-        const songs = await response.json();
-        renderSongList(songs);
-        if (songs.length > 0) {
-          setCurrentSong(songs[0], songs);
-        } else {
-          showEmptyState();
+  <script type="module">
+    import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js';
+    import {
+      getFirestore,
+      collection,
+      query,
+      orderBy,
+      limit,
+      onSnapshot,
+      addDoc,
+      serverTimestamp,
+    } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js';
+
+    let db = null;
+    let songsCache = [];
+    let currentSongId = null;
+    let unsubscribeSongs = null;
+    let firebaseInitPromise = null;
+
+    async function initFirebase() {
+      if (firebaseInitPromise) return firebaseInitPromise;
+
+      firebaseInitPromise = (async () => {
+        const response = await fetch('/api/firebase-config');
+        if (!response.ok) {
+          throw new Error('Unable to load Firebase configuration.');
         }
-      } catch (err) {
-        console.error(err);
-        showEmptyState('We had trouble loading today\'s playlist. Please refresh to try again.');
-      }
+
+        const config = await response.json();
+        const app = initializeApp(config);
+        db = getFirestore(app);
+        return db;
+      })();
+
+      return firebaseInitPromise;
     }
 
-    function showEmptyState(message = 'No songs are available right now. Check back soon!') {
-      const list = document.getElementById('songList');
-      list.innerHTML = `<li class="empty-state">${message}</li>`;
-    }
-
-    function renderSongList(songs) {
-      const list = document.getElementById('songList');
-      const template = document.getElementById('songItemTemplate');
-      list.innerHTML = '';
-
-      songs.forEach((song, index) => {
-        const clone = template.content.cloneNode(true);
-        const button = clone.querySelector('button');
-        const title = clone.querySelector('.song-title');
-        const meta = clone.querySelector('.song-meta');
-
-        title.textContent = song.title;
-        meta.textContent = `${song.artist} • ${formatDate(song.date)}`;
-
-        button.dataset.index = index;
-        button.addEventListener('click', () => setCurrentSong(song, songs));
-
-        list.appendChild(clone);
-      });
-    }
-
-    function formatDate(dateString) {
-      const date = new Date(dateString + 'T00:00:00');
-      return date.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
-    }
-
-    function setCurrentSong(song, songs) {
+    function resetNowPlaying() {
       const title = document.getElementById('songTitle');
       const meta = document.getElementById('songMeta');
       const description = document.getElementById('songDescription');
@@ -338,16 +327,115 @@
       const source = document.getElementById('audioSource');
       const tag = document.getElementById('songTag');
 
-      title.textContent = song.title;
-      meta.textContent = `${song.artist} — featured ${formatDate(song.date)}`;
-      description.textContent = song.description;
-      source.src = song.streamUrl;
+      title.textContent = 'Waiting for a spin';
+      meta.textContent = 'Generate a Suno song to start your listening session.';
+      description.textContent = 'Lyrics will appear here after you generate a track.';
+      source.src = '';
       audio.load();
-      audio.play().catch(() => {
-        // Ignore autoplay rejection, user interaction will be required on some browsers
-      });
+      tag.textContent = 'Now Playing';
+      tag.style.background = 'rgba(245, 158, 11, 0.18)';
+      tag.style.color = 'var(--accent)';
+    }
 
-      if (song.isToday) {
+    function showEmptyState(message = 'No songs are available right now. Generate one to get started!') {
+      const list = document.getElementById('songList');
+      if (!list) return;
+      list.innerHTML = `<li class="empty-state">${message}</li>`;
+    }
+
+    function formatDate(date) {
+      if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+        return '';
+      }
+      return date.toLocaleDateString(undefined, {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+      });
+    }
+
+    function formatTime(date) {
+      if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+        return '';
+      }
+      return date.toLocaleTimeString(undefined, {
+        hour: 'numeric',
+        minute: '2-digit',
+      });
+    }
+
+    function formatDateTime(date) {
+      const datePart = formatDate(date);
+      const timePart = formatTime(date);
+      if (datePart && timePart) return `${datePart} • ${timePart}`;
+      return datePart || timePart || 'Generated';
+    }
+
+    function renderSongList(songs) {
+      songsCache = songs;
+      const list = document.getElementById('songList');
+      const template = document.getElementById('songItemTemplate');
+
+      if (!songs.length) {
+        showEmptyState('No Suno songs have been generated yet. Be the first to spin one!');
+        return;
+      }
+
+      list.innerHTML = '';
+
+      songs.forEach((song) => {
+        const clone = template.content.cloneNode(true);
+        const button = clone.querySelector('button');
+        const title = clone.querySelector('.song-title');
+        const meta = clone.querySelector('.song-meta');
+
+        title.textContent = song.title;
+        const metaPieces = [];
+        if (song.artist) metaPieces.push(song.artist);
+        metaPieces.push(formatDateTime(song.createdAt));
+        meta.textContent = metaPieces.filter(Boolean).join(' • ');
+
+        button.dataset.id = song.id || '';
+        button.classList.toggle('active', Boolean(song.id && song.id === currentSongId));
+        button.addEventListener('click', () => {
+          setCurrentSong(song);
+        });
+
+        list.appendChild(clone);
+      });
+    }
+
+    function setCurrentSong(song) {
+      if (!song) {
+        resetNowPlaying();
+        return;
+      }
+
+      currentSongId = song.id || null;
+
+      const title = document.getElementById('songTitle');
+      const meta = document.getElementById('songMeta');
+      const description = document.getElementById('songDescription');
+      const audio = document.getElementById('audioPlayer');
+      const source = document.getElementById('audioSource');
+      const tag = document.getElementById('songTag');
+
+      title.textContent = song.title || 'Daily Spin (Suno)';
+      const metaPieces = [];
+      metaPieces.push(song.artist || 'Suno AI');
+      const formatted = formatDateTime(song.createdAt);
+      if (formatted) metaPieces.push(formatted);
+      meta.textContent = metaPieces.join(' — ');
+
+      description.textContent = song.lyrics || 'Your Suno track is ready. Enjoy!';
+      source.src = song.audioUrl || '';
+      audio.load();
+      if (song.audioUrl) {
+        audio.play().catch(() => {});
+      }
+
+      const isNewest = songsCache.length > 0 && songsCache[0]?.id === song.id;
+      if (isNewest) {
         tag.textContent = 'Now Playing';
         tag.style.background = 'rgba(245, 158, 11, 0.18)';
         tag.style.color = 'var(--accent)';
@@ -357,59 +445,83 @@
         tag.style.color = 'var(--text)';
       }
 
-      const buttons = document.querySelectorAll('.song-list button');
-      buttons.forEach((button) => {
-        const index = Number(button.dataset.index);
-        const isActive = songs[index].title === song.title && songs[index].date === song.date;
-        button.classList.toggle('active', isActive);
+      document.querySelectorAll('.song-list button').forEach((button) => {
+        button.classList.toggle('active', button.dataset.id === (song.id || ''));
       });
     }
 
-    function describeSunoResult(result) {
-      if (!result || typeof result !== 'object') {
-        return '';
+    async function subscribeToSongs() {
+      if (!db) return;
+
+      if (unsubscribeSongs) {
+        unsubscribeSongs();
       }
 
-      if (Array.isArray(result.data) && result.data.length > 0) {
-        const first = result.data[0];
-        const identifier = first.id || first.song_id || first.audio_id || first.task_id;
-        if (identifier) {
-          return `Suno request queued (ID: ${identifier}).`;
-        }
-      }
+      const songsRef = collection(db, 'spins');
+      const songsQuery = query(songsRef, orderBy('createdAt', 'desc'), limit(50));
 
-      if (result.id || result.song_id || result.audio_id) {
-        const identifier = result.id || result.song_id || result.audio_id;
-        return `Suno request queued (ID: ${identifier}).`;
-      }
+      unsubscribeSongs = onSnapshot(
+        songsQuery,
+        (snapshot) => {
+          const songs = snapshot.docs
+            .map((doc) => {
+              const data = doc.data();
+              const createdAt =
+                (data.createdAt && typeof data.createdAt.toDate === 'function'
+                  ? data.createdAt.toDate()
+                  : data.generatedAtIso
+                  ? new Date(data.generatedAtIso)
+                  : null);
 
-      if (result.status) {
-        return `Suno responded with status: ${result.status}.`;
-      }
+              return {
+                id: doc.id,
+                title: data.title || 'Daily Spin (Suno)',
+                artist: data.artist || 'Suno AI',
+                lyrics: data.lyrics || '',
+                audioUrl: data.audioUrl || data.streamUrl || '',
+                createdAt,
+              };
+            })
+            .filter((song) => Boolean(song.audioUrl));
 
-      return '';
+          if (!songs.length) {
+            currentSongId = null;
+            songsCache = [];
+            showEmptyState('No Suno songs have been generated yet. Be the first to spin one!');
+            resetNowPlaying();
+            return;
+          }
+
+          renderSongList(songs);
+
+          const selected = currentSongId
+            ? songs.find((entry) => entry.id === currentSongId)
+            : null;
+
+          if (selected) {
+            setCurrentSong(selected);
+          } else {
+            setCurrentSong(songs[0]);
+          }
+        },
+        (error) => {
+          console.error('Failed to load songs from Firebase:', error);
+          showEmptyState('Unable to load recent spins right now.');
+        },
+      );
     }
 
-    async function pollForAudio(clipIds, { timeoutMs = 120000, intervalMs = 2500 } = {}) {
-      const start = Date.now();
-      while (Date.now() - start < timeoutMs) {
-        const qs = encodeURIComponent(clipIds.join(','));
-        const r = await fetch(`/api/song-status?clip_ids=${qs}`);
-        if (!r.ok) {
-          const err = await r.json().catch(() => ({}));
-          throw new Error(err.error || 'Status check failed');
-        }
-        const { data = [] } = await r.json();
-        const ready = data.find(d => d.state === 'succeeded' && d.audio_url);
-        if (ready) return ready;
-
-        await new Promise(res => setTimeout(res, intervalMs));
+    async function loadSongs() {
+      try {
+        await initFirebase();
+        subscribeToSongs();
+      } catch (error) {
+        console.error('Unable to initialise Firebase:', error);
+        showEmptyState('We had trouble loading the recent spins. Please try again soon.');
       }
-      throw new Error('Timed out waiting for Suno audio.');
     }
 
     function populateFromSuno(clip) {
-      // clip: { clip_id, title, audio_url, image_url, video_url, mv, duration, created_at, ... }
       const audio = document.getElementById('audioPlayer');
       const source = document.getElementById('audioSource');
       const title = document.getElementById('songTitle');
@@ -417,15 +529,22 @@
       const desc = document.getElementById('songDescription');
       const tag = document.getElementById('songTag');
 
+      const createdAt = clip.created_at ? new Date(clip.created_at) : new Date();
+
       title.textContent = clip.title || 'Daily Spin (Suno)';
-      meta.textContent = `Generated • ${new Date(clip.created_at || Date.now()).toLocaleString()}`;
+      meta.textContent = `Suno AI — ${formatDateTime(createdAt)}`;
       desc.textContent = clip.lyrics || 'Your Suno track is ready. Enjoy!';
-      source.src = clip.audio_url;
+      source.src = clip.audio_url || '';
       audio.load();
-      audio.play().catch(() => {});
+      if (clip.audio_url) {
+        audio.play().catch(() => {});
+      }
+
       tag.textContent = 'Now Playing';
       tag.style.background = 'rgba(245, 158, 11, 0.18)';
       tag.style.color = 'var(--accent)';
+
+      currentSongId = null;
     }
 
     async function pollForAudioIds({ taskIds = [], clipIds = [] }, { timeoutMs = 180000, intervalMs = 15000 } = {}) {
@@ -442,14 +561,35 @@
         }
 
         const { data = [] } = await r.json();
-        const ready = data.find(d => d.state === 'succeeded' && d.audio_url);
+        const ready = data.find((d) => d.state === 'succeeded' && d.audio_url);
         if (ready) return ready;
 
-        await new Promise(res => setTimeout(res, intervalMs));
+        await new Promise((res) => setTimeout(res, intervalMs));
       }
       throw new Error('Timed out waiting for Suno audio.');
     }
 
+    async function saveGeneratedSong(clip, prompt) {
+      await initFirebase();
+      if (!db) throw new Error('Firebase is not available.');
+
+      if (!clip || !clip.audio_url) {
+        throw new Error('Suno did not return an audio URL to save.');
+      }
+
+      const songsRef = collection(db, 'spins');
+      const nowIso = new Date().toISOString();
+
+      await addDoc(songsRef, {
+        title: clip.title || 'Daily Spin (Suno)',
+        artist: clip.artist || 'Suno AI',
+        lyrics: (clip.lyrics || '').trim(),
+        audioUrl: clip.audio_url,
+        prompt: prompt || '',
+        createdAt: serverTimestamp(),
+        generatedAtIso: nowIso,
+      });
+    }
 
     async function generateSongFromNews() {
       const button = document.getElementById('generateSongButton');
@@ -480,7 +620,18 @@
 
         const clip = await pollForAudioIds({ taskIds, clipIds }, { timeoutMs: 180000, intervalMs: 15000 });
         populateFromSuno(clip);
-        status.textContent = 'Your Suno song is ready. Enjoy!';
+
+        let saved = false;
+        try {
+          await saveGeneratedSong(clip, body.prompt);
+          saved = true;
+        } catch (persistError) {
+          console.error('Failed to save song to Firebase:', persistError);
+        }
+
+        status.textContent = saved
+          ? 'Your Suno song is ready and saved to Recent Spins.'
+          : 'Your Suno song is ready, but it could not be saved to Recent Spins.';
       } catch (error) {
         console.error('Failed to generate Suno song:', error);
         status.textContent = error.message || 'Something went wrong while generating the song.';
@@ -488,7 +639,6 @@
         button.disabled = false;
       }
     }
-
 
     document.addEventListener('DOMContentLoaded', () => {
       loadSongs();


### PR DESCRIPTION
## Summary
- add an API endpoint that exposes the Firebase configuration for the frontend
- replace the static playlist with a Firebase-backed recent spins list and improved lyrics layout
- persist newly generated Suno tracks to Firebase with timestamps, audio URLs, and lyrics

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e5c1079f10832588ec9a6bca97a93e