### PR TITLE
Prevent autoplay when recent spins hydrate on page load

### DIFF
--- a/components/index.html
+++ b/components/index.html
@@ -2358,7 +2358,9 @@
         // When a podcast is mid-playback, avoid auto-switching to a new
         // item (which could hijack the player and clear the podcast scripts).
         if(selected){
-          setCurrentSong(selected);
+          // Keep the current selection in sync without starting playback
+          // when snapshot updates arrive during initial page load.
+          setCurrentSong(selected, { autoPlay: false });
         } else if(!podcastIsPlaying && merged[0]){
           setCurrentSong(merged[0], { autoPlay: false });
         }


### PR DESCRIPTION
### Motivation
- Snapshot-driven hydration of the recent spins list called `setCurrentSong` (which defaults to autoplay) and caused the first available recent spin to begin playing automatically on page load, which is undesirable for initial visits.

### Description
- Updated the refresh path in `components/index.html` to call `setCurrentSong(selected, { autoPlay: false })` during snapshot-driven refreshes so the selection is synced without starting playback, while leaving user-initiated `setCurrentSong(song)` clicks unchanged.

### Testing
- No automated tests are configured for this repository, so no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c53536de8c83318e398ebe5372feea)